### PR TITLE
Handling underscores in workspace paths

### DIFF
--- a/src/providers/ClaudeCodeWatcher.ts
+++ b/src/providers/ClaudeCodeWatcher.ts
@@ -343,7 +343,7 @@ export class ClaudeCodeWatcher implements IConversationProvider {
    * C:\Users\foo\project → C-Users-foo-project (BUG20: Windows backslash + colon)
    */
   private encodeWorkspacePath(workspacePath: string): string {
-    return workspacePath.replace(/[/\\.:]/g, '-');
+    return workspacePath.replace(/[/\\.:_]/g, '-');
   }
 
   // ── Project discovery & progressive scanning (standalone) ─────────


### PR DESCRIPTION
## Summary

When naming projects from workspace paths, Claude Code replaces underscores with hyphens the same way it does slashes, periods, and colons.

## Checklist

- [x] `npm test` passes
- [x] `npm run lint` passes
- [x] Webview builds (`cd webview && npm run build`)
- [x] Tested manually in the Extension Development Host
- [x] Updated `CHANGELOG.md` (if user-facing change)
- [x] User-facing strings use `vscode.l10n.t()` for i18n
