### PR TITLE
Encode spaces in workspace paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ### Fixed
 
 - Summarization on Windows: `resolveExecutable` now uses `which` or `where` depending on platform, enabling Summarization on Windows
-- Workspace path reconstruction (`ConversationParser`) — replaced the greedy hyphen-split + `fsp.access` existence-check approach with a filesystem walk that re-encodes each candidate path using Claude's own algorithm; paths containing dots (`user.name`), underscores (`my_project`), or Windows drive-letter colons (`C:`) are now resolved correctly on all platforms
+- Workspace path reconstruction (`ConversationParser`) — replaced the greedy hyphen-split + `fsp.access` existence-check approach with a filesystem walk; paths containing spaces, dots (`user.name`), underscores (`my_project`), or Windows drive-letter colons (`C:`) are now resolved correctly on all platforms
 - Windows workspace encoding (`ClaudeCodeWatcher`) — `encodeWorkspacePath` normalizes backslashes before encoding and applies case folding on case-insensitive platforms (Windows/macOS), matching Claude Code's encoding exactly; fixes conversations from Windows projects not appearing on the board
 - Standalone terminal resumption on Windows — tries Windows Terminal (`wt`) before falling back to `cmd /c start`
 - Standalone conversation "open in terminal" dropdown immediately closing — `stopPropagation` on the button click prevents the window-level handler from dismissing the menu before it renders

--- a/src/providers/ClaudeCodeWatcher.ts
+++ b/src/providers/ClaudeCodeWatcher.ts
@@ -423,7 +423,7 @@ export class ClaudeCodeWatcher implements IConversationProvider {
    */
   private encodeWorkspacePath(workspacePath: string, lowercase: boolean = false): string {
     const normalizedWorkspacePath = this.normalizePath(workspacePath, lowercase);
-    return normalizedWorkspacePath.replace(/[/.:_]/g, '-');
+    return normalizedWorkspacePath.replace(/[/.:_ ]/g, '-');
   }
 
   private resolveWorkspacePathForFile(filePath: string): string | undefined {

--- a/src/providers/ConversationParser.ts
+++ b/src/providers/ConversationParser.ts
@@ -1012,8 +1012,8 @@ export class ConversationParser {
    */
   private async resolveEncodedPath(encoded: string, currentPath: string, ignoreCase = false): Promise<string | undefined> {
     const currentEncoded = ignoreCase
-      ? currentPath.replace(/[/\\.:_]/g, '-').toLowerCase()
-      : currentPath.replace(/[/\\.:_]/g, '-');
+      ? currentPath.replace(/[/\\.:_ ]/g, '-').toLowerCase()
+      : currentPath.replace(/[/\\.:_ ]/g, '-');
 
     if (currentEncoded === encoded) return currentPath;
     if (!encoded.startsWith(currentEncoded)) return undefined;


### PR DESCRIPTION
## Summary

Fixes #10 

## Checklist

- [x] `npm test` passes
- [x] `npm run lint` passes
- [x] Webview builds (`cd webview && npm run build`)
- [x] Tested manually in the Extension Development Host
- [x] Updated `CHANGELOG.md` (if user-facing change)
- [x] User-facing strings use `vscode.l10n.t()` for i18n
