### PR TITLE
Bugfix: Summaries on Windows

### DIFF
--- a/src/services/SummaryService.ts
+++ b/src/services/SummaryService.ts
@@ -188,7 +188,6 @@ Return ONLY a JSON array in the same order: [{"title":"...","description":"...",
       const child = spawn(backend.path, args, {
         cwd: os.tmpdir(),
         env: CHILD_ENV,
-        shell: process.platform === 'win32',  // required to execute .cmd/.bat files on Windows
         signal: ac.signal,
       });
 
@@ -266,8 +265,7 @@ Return ONLY a JSON array in the same order: [{"title":"...","description":"...",
         const binPath = stdout.trim().split('\n')[0].trim();
         const child = spawn(binPath, ['--version'], {
           timeout: CLI_CHECK_TIMEOUT_MS,
-          env: CHILD_ENV,
-          shell: isWindows  // required to execute .cmd/.bat files on Windows
+          env: CHILD_ENV
         });
         child.on('error', () => resolve(undefined));
         child.on('close', (code) => resolve(code === 0 ? binPath : undefined));

--- a/standalone/StandaloneMessageHandler.ts
+++ b/standalone/StandaloneMessageHandler.ts
@@ -365,7 +365,7 @@ export class StandaloneMessageHandler {
 
   /** Open a workspace folder in an editor (VSCode, Cursor, etc.). */
   private openInEditor(cmd: string, cwd: string) {
-    execFile(cmd, [cwd], { shell: process.platform === 'win32' }, (err) => {
+    execFile(cmd, [cwd], (err) => {
       if (err) {
         console.error(`Claudine: Failed to open ${cmd}`, err);
         this._send({ type: 'error', message: `Failed to open ${cmd}: ${err.message}` });

--- a/standalone/StandaloneMessageHandler.ts
+++ b/standalone/StandaloneMessageHandler.ts
@@ -376,11 +376,23 @@ export class StandaloneMessageHandler {
   /** Resume a Claude Code conversation in a terminal emulator. */
   private openInTerminal(cwd: string, sessionId: string) {
     const platform = process.platform;
-    // Strip Node.js debugger variables that interfere with child processes (mainly relevant to
-    // VS Code debug sessions). NODE_OPTIONS may carry debugger bootstrap flags (--require) that
-    // claude's embedded Node can't resolve.
-    const env = { ...process.env };
-    delete env['NODE_OPTIONS'];
+    // Use a minimal env to avoid leaking secrets and stripping Node.js debugger
+    // variables (e.g. NODE_OPTIONS) that interfere with child processes.
+    const env: NodeJS.ProcessEnv = {
+      PATH: process.env.PATH,
+      HOME: process.env.HOME,
+      LANG: process.env.LANG,
+      TERM: process.env.TERM,
+      // Windows: needed for terminal emulators to locate config dirs and resolve .cmd files
+      ...(platform === 'win32' && {
+        APPDATA: process.env.APPDATA,
+        USERPROFILE: process.env.USERPROFILE,
+        PATHEXT: process.env.PATHEXT,
+        SystemRoot: process.env.SystemRoot,
+        TEMP: process.env.TEMP,
+        TMP: process.env.TMP,
+      }),
+    };
 
     const resumeCmd = `claude --resume ${sessionId}`;
 


### PR DESCRIPTION
## Summary

Fixes #13: since [this commit](https://github.com/salam/claudine/commit/37bcdb641faca35bb4d51c2a328f9a0b5b9c965a#diff-5c2eb28b76fa03b2b9e50914c35811a156f226538187aca56ff2068200a75c52) moved the Summaries prompt string from stdin to a CLI arg, AI summaries have been broken on Windows.

That said: the real source of the problem seems to have been [my last PR](#3) on this feature where I set `shell: true` for multiple child process calls on Windows. This evidently made Windows CMD unable to handle the newlines in the prompt string, and from what I can tell: it was never necessary in the first place, and might even have had security implications. Claude, ironically, led me wrong on that one 🙃

## Changes

- Removes the `shell: true` child process argument in several places (all tested to have no impact on Windows)
- In a similar vein: strips the environment passed by `StandaloneMessageHandler.ts` to child processes, similar to how `SummaryService.ts` does it

## Checklist

- [x] `npm test` passes
- [x] `npm run lint` passes
- [x] Webview builds (`cd webview && npm run build`)
- [x] Tested manually in the Extension Development Host
- [x] Updated `CHANGELOG.md` (if user-facing change)
- [x] User-facing strings use `vscode.l10n.t()` for i18n
